### PR TITLE
feat: update basic chat bubble ui with props and story

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from "@storybook/react";
+import "../src/index.css";
 
 const preview: Preview = {
   parameters: {

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from "@storybook/react";
+// this is needed to import the css in our app to storybook preview app
 import "../src/index.css";
 
 const preview: Preview = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-slot": "^1.1.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "dayjs": "^1.11.13",
         "lucide-react": "^0.447.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3975,6 +3976,12 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "dayjs": "^1.11.13",
     "lucide-react": "^0.447.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -42,7 +42,6 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    console.log("buttonVariants", buttonVariants({ variant, size, className }));
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}

--- a/src/modules/chat/components/ChatBubble/ChatBubble.stories.ts
+++ b/src/modules/chat/components/ChatBubble/ChatBubble.stories.ts
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react";
+// import { fn } from "@storybook/test";
+
+import { ChatBubble } from "./ChatBubble";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: "Chat/ChatBubble",
+  component: ChatBubble,
+  parameters: {
+    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+    layout: "centered",
+  },
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+  //     argTypes: {
+
+  //     backgroundColor: { control: "variant" },
+  //   },
+  // Use `fn` to spy on the onClick arg, which will appear in the actions panel once invoked: https://storybook.js.org/docs/essentials/actions#action-args
+  //   args: { onClick: fn() },
+} satisfies Meta<typeof ChatBubble>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Sender: Story = {
+  args: {
+    variant: "sender",
+    messageText: "Hello!",
+    messageSentAt: new Date().toISOString(),
+  },
+};
+
+export const Receiver: Story = {
+  args: {
+    variant: "receiver",
+    messageText: "Hi!",
+    messageSentAt: new Date().toISOString(),
+  },
+};

--- a/src/modules/chat/components/ChatBubble/ChatBubble.tsx
+++ b/src/modules/chat/components/ChatBubble/ChatBubble.tsx
@@ -1,13 +1,73 @@
-import React from "react";
-import { Card } from "@/components/ui/card";
+import * as React from "react";
+import { cva } from "class-variance-authority";
+import { toCalendarTime } from "@/modules/core/utils/time";
+import { cn } from "@/lib/utils";
+// import clsx from "clsx";
 
-export const ChatBubble = () => {
+const chatBubbleVariants = cva(
+  "rounded-md border bg-white px-2 py-1 shadow-sm max-w-xs grow-0",
+  {
+    variants: {
+      variant: {
+        sender: "bg-green-200 self-end",
+        receiver: "bg-white self-start",
+      },
+    },
+    defaultVariants: {
+      variant: "sender",
+    },
+  },
+);
+
+export type ChatBubbleProps = {
+  /** bubble style for sender and receiver */
+  variant: "sender" | "receiver";
+  /** display caret in bubble for first message sent by the user */
+  displayCaret?: boolean;
+  /** the sender name used to display on top of the message bubble */
+  senderName?: string;
+  /** the sender phone number for fallback if sender name is not available */
+  senderPhoneNumber?: string;
+  /** the sender profile picture url image if any */
+  senderProfilePicture?: string;
+  /** the message text content  */
+  messageText: string;
+  /**  when the message sent in utc string timestamp format */
+  messageSentAt: string;
+} & React.HTMLAttributes<HTMLDivElement>;
+// & VariantProps<typeof chatBubbleVariants>; // note: even though this will add the props of variants, but we can't annotate the props description for storybook.
+
+// Chat Bubble UI used in chat conversation
+export const ChatBubble = ({
+  variant = "sender",
+  senderName,
+  messageText,
+  messageSentAt,
+  className,
+}: ChatBubbleProps) => {
+  // other example of using clsx only, without cva
+  // const classes = clsx(
+  //   "rounded-md border bg-white px-2 py-1 shadow-sm max-w-xs grow-0",
+  //   {
+  //     "bg-green-200 self-end": variant === "sender",
+  //     "bg-white self-start": variant === "receiver",
+  //   },
+  //   className,
+  // );
+  // console.log(`additional class ${variant}:`, classes);
+
   return (
-    <Card className="max-w-xs self-start px-3 py-2">
-      <div>
-        <span className="text-md">Halo halo</span>
+    <div className={cn(chatBubbleVariants({ variant, className }))}>
+      <div className="flex flex-row">
+        {senderName && <h6>{senderName}</h6>}
+        <span className="text-sm">{messageText}</span>
+
+        {messageSentAt && (
+          <span className="mt-2 self-end pl-2 text-[10px] text-slate-500">
+            {toCalendarTime(messageSentAt)}
+          </span>
+        )}
       </div>
-      <div className="text-right text-xs">21:20</div>
-    </Card>
+    </div>
   );
 };

--- a/src/modules/chat/components/ChatDetailContainer/ChatDetailContainer.tsx
+++ b/src/modules/chat/components/ChatDetailContainer/ChatDetailContainer.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-import { Card } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import ChatBubble from "../ChatBubble";
 import ChatDetailHeader from "../ChatDetailHeader";
@@ -12,14 +10,29 @@ export const ChatDetailContainer = () => {
 
       <ScrollArea>
         <div className="flex h-svh flex-col gap-1 px-8 pb-8 pt-20">
-          <Card className="max-w-xs self-start px-3 py-2">
-            <div>
-              <span className="text-md">Halo halo</span>
-            </div>
-            <div className="text-right text-xs">21:20</div>
-          </Card>
+          <ChatBubble
+            variant="receiver"
+            messageText="Halo"
+            messageSentAt={new Date().toISOString()}
+          />
+          <ChatBubble
+            variant="sender"
+            messageText="Hai"
+            messageSentAt={new Date().toISOString()}
+          />
+          <ChatBubble
+            variant="receiver"
+            messageText="Apa kabar?"
+            messageSentAt={new Date().toISOString()}
+          />
+          <ChatBubble
+            variant="sender"
+            messageText="baik"
+            messageSentAt={new Date().toISOString()}
+          />
 
-          <div className="max-w-full">
+          {/* todo: example component for horizontal scroll messages */}
+          {/* <div className="max-w-full">
             <div className="flex snap-x snap-mandatory gap-1 overflow-x-auto">
               <div className="w-80 flex-none shrink-0 snap-center"></div>
               <Card className="w-80 flex-none snap-center bg-green-200 px-3 py-2">
@@ -56,11 +69,7 @@ export const ChatDetailContainer = () => {
                 <div className="text-right text-xs">21:20</div>
               </Card>
             </div>
-
-            <ChatBubble />
-            <ChatBubble />
-            <ChatBubble />
-          </div>
+          </div> */}
         </div>
       </ScrollArea>
 

--- a/src/modules/core/utils/time.ts
+++ b/src/modules/core/utils/time.ts
@@ -1,0 +1,12 @@
+import dayjs from "dayjs";
+import calendar from "dayjs/plugin/calendar";
+
+dayjs.extend(calendar);
+
+// todo: add the tests
+export function toCalendarTime(isoDate: string) {
+  return dayjs().calendar(dayjs(isoDate), {
+    sameDay: "hh:mm",
+    lastDay: "Yesterday",
+  });
+}


### PR DESCRIPTION
## Screenshots

<img width="705" alt="Screenshot 2024-10-11 at 08 05 18" src="https://github.com/user-attachments/assets/fb108e96-b7d9-4e2a-82f6-3af001201e15">

<img width="1728" alt="Screenshot 2024-10-11 at 08 06 05" src="https://github.com/user-attachments/assets/c0ae20ca-2953-4ca3-a6c0-ed492159c525">


## What I did

- Update the ChatBubble component to accept props of the text content and UI variants, currently, it only accepts plain text.
  -  I am using class-variance-authority library to build the conditional classes, this is what I learned from how shadcn UI is built their component. I learned that using it can automatically generate the props variant, but if we didn't state explicitly in props, I can't use the autodocs gen in the storybook. I put some inline comments on the code on what I mean by this.
  - I also try to use the conditional classes using clsx, I put as comments for reference.
  - I create a util function for generate the display time for when the chat are sent
- Add the storybook for documenting the ChatBubble UI, I still put some commented code there for reference.

## Other unrelated chore things that I did
- remove the log in Button component
- commented component message media horizontal scroll that I did last time for POC in static UI


## Note
This PR is not clean but I am planning to merge this first so that I can go to other parts first. Will flesh out this later on separate PR.